### PR TITLE
Add sharerId to gatekeeper.perms

### DIFF
--- a/lib/dataBroker.js
+++ b/lib/dataBroker.js
@@ -116,7 +116,7 @@ module.exports = function(config, mongoClient) {
         return process.nextTick(cb);
       }
 
-      sharerId = groupId;
+      var sharerId = groupId;
       groupId = encrypt(groupId);
 
       if (permissions == null) {


### PR DESCRIPTION
This adds the unencrypted values of the shared userid field to the mongo record for NEW shares of DSA accounts.

Tested on QA2.

Addresses #BACK-1674