### PR TITLE
[BACK-1897] [BACK-1906] Use aggregation pipeline for clinic and clinician permissions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,16 @@ node_js:
 install:
   - npm install
 
-before_script:
-  - curl https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -
-  - echo "deb https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/4.4 multiverse" | sudo tee -a /etc/apt/sources.list
-  - sudo apt-get -qq update
-  - sudo apt-get -y install mongodb-org
-  - sudo systemctl start mongod
+env:
+  global:
+  - MONGODB=4.4.1
+before_install:
+- sudo apt-get remove -y mongodb-org mongodb-org-mongos mongodb-org-server mongodb-org-shell mongodb-org-tools
+- wget https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-${MONGODB}.tgz -O /tmp/mongodb.tgz
+- tar -xf /tmp/mongodb.tgz
+- mkdir /tmp/data
+- ${PWD}/mongodb-linux-x86_64-ubuntu1804-${MONGODB}/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 --logpath ${PWD}/mongod.log &> /dev/null &
+- until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done
 
 addons:
   artifacts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,14 @@ node_js:
 install:
   - npm install
 
+before_script:
+  - curl https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -
+  - echo "deb https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/4.4 multiverse" | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get -qq update
+  - sudo apt-get -y install mongodb-org
+  - sudo systemctl start mongod
+
 addons:
-  apt:
-    sources:
-      - mongodb-3.2-trusty
-    packages:
-      - mongodb-org-server
   artifacts:
     s3_region: us-west-2
     paths:
@@ -23,7 +25,7 @@ addons:
 
 services:
   - docker
-  - mongodb
+  - mongodb 
 
 script:
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+dist: focal
 
 language: node_js
 
@@ -11,12 +11,13 @@ install:
 env:
   global:
   - MONGODB=4.4.1
+
 before_install:
 - sudo apt-get remove -y mongodb-org mongodb-org-mongos mongodb-org-server mongodb-org-shell mongodb-org-tools
-- wget https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-${MONGODB}.tgz -O /tmp/mongodb.tgz
+- wget https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-${MONGODB}.tgz -O /tmp/mongodb.tgz
 - tar -xf /tmp/mongodb.tgz
 - mkdir /tmp/data
-- ${PWD}/mongodb-linux-x86_64-ubuntu1804-${MONGODB}/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 --logpath ${PWD}/mongod.log &> /dev/null &
+- ${PWD}/mongodb-linux-x86_64-ubuntu2004-${MONGODB}/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 --logpath ${PWD}/mongod.log &> /dev/null &
 - until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ addons:
 
 services:
   - docker
-  - mongodb 
 
 script:
   - npm run lint

--- a/lib/dataBroker.js
+++ b/lib/dataBroker.js
@@ -32,37 +32,40 @@ module.exports = function(mongoClient) {
 
       withPerms(cb, function(perms, doneCb) {
         perms.aggregate([
-          // Find all user -> user and user -> clinic permissions
-          { $match: {
-              $or: [
-                {'sharerId': sharerId, 'userId': userId},
-                {'patientId': sharerId}
-              ] }
+          // Find all user (subject) -> user (principal) permissions
+          { $match: {'sharerId': sharerId, 'userId': userId} },
+          // Find all user (subject) -> clinic -> clinician (principal) permissions
+          { $unionWith:
+              {
+                coll: 'patient_permissions',
+                pipeline: [
+                  // Find all patient -> clinic permissions
+                  { $match: {'userId': sharerId } },
+                  { $lookup: {
+                      // Join all clinic -> clinician permissions
+                      from: 'clinician_permissions',
+                      let: { clinicId: '$clinicId' },
+                      as: 'clinician',
+                      pipeline: [
+                        { $match: {
+                            $expr: {
+                              $and: [
+                                // Join on clinician = userId (principal)
+                                { $eq: ['$userId', userId]},
+                                { $eq: ['$clinicId','$$clinicId']},
+                              ]
+                            }
+                          }},
+                        { $project: { 'clinicianId': '$userId' } },
+                      ],
+                    }},
+                  { $unwind: { path: '$clinician', preserveNullAndEmptyArrays: true } },
+                  { $replaceRoot: { newRoot: { $mergeObjects: [ '$clinician', '$$ROOT' ] } } },
+                  { $match: { 'clinicianId': { $exists: true } } },
+                  { $project: { _id: 0, permissions: 1 } },
+                ]
+              }
           },
-          // Outer join clinic -> clinician permissions on the clinician userId
-          { $lookup: {
-              from: 'clinician_permissions',
-              let: { clinicId: '$clinicId' },
-              as: 'clinician',
-              pipeline: [
-                {
-                  $match: {
-                    $expr: {
-                      $and: [
-                        { $eq: ['$clinicId','$$clinicId']},
-                        { $eq: ['$userId', userId]}
-                      ]
-                    }
-                  }
-                },
-              ],
-            }
-          },
-          { $unwind: { path: '$clinician', preserveNullAndEmptyArrays: true } },
-          { $replaceRoot: { newRoot: { $mergeObjects: [ '$clinician', '$$ROOT' ] } } },
-          // Filter out results where the outer join produced no results
-          { $match: { 'userId': {$exists: true } } },
-          { $project: { _id: 0, permissions: 1 } },
         ]).toArray(function (err, data) {
           if (err != null) {
             cb(err);

--- a/lib/dataBroker.js
+++ b/lib/dataBroker.js
@@ -5,8 +5,6 @@
 'use strict';
 
 var _ = require('lodash');
-var amoeba = require('amoeba');
-var except = amoeba.except;
 
 module.exports = function(mongoClient) {
   function withPerms(sadCb, happyCb) {
@@ -27,30 +25,61 @@ module.exports = function(mongoClient) {
   }
 
   return {
-
     userInGroup: function(userId, sharerId, cb) {
       if (userId === sharerId) {
         return process.nextTick(function(){ cb(null, {root: {}}); });
       }
 
       withPerms(cb, function(perms, doneCb) {
-        var retVal = null;
+        perms.aggregate([
+          // Find all user -> user and user -> clinic permissions
+          { $match: {
+              $or: [
+                {'sharerId': sharerId, 'userId': userId},
+                {'patientId': sharerId}
+              ] }
+          },
+          // Outer join clinic -> clinician permissions on the clinician userId
+          { $lookup: {
+              from: 'clinician_permissions',
+              let: { clinicId: '$clinicId' },
+              as: 'clinician',
+              pipeline: [
+                {
+                  $match: {
+                    $expr: {
+                      $and: [
+                        { $eq: ['$clinicId','$$clinicId']},
+                        { $eq: ['$userId', userId]}
+                      ]
+                    }
+                  }
+                },
+              ],
+            }
+          },
+          { $unwind: { path: '$clinician', preserveNullAndEmptyArrays: true } },
+          { $replaceRoot: { newRoot: { $mergeObjects: [ '$clinician', '$$ROOT' ] } } },
+          // Filter out results where the outer join produced no results
+          { $match: { 'userId': {$exists: true } } },
+          { $project: { _id: 0, permissions: 1 } },
+        ]).toArray(function (err, data) {
+          if (err != null) {
+            cb(err);
+            return;
+          }
 
-        perms.find({sharerId: sharerId, userId: userId}, {permissions: 1})
-          .stream()
-          .on('data', function(data){
-                if (retVal == null) {
-                  retVal = data.permissions;
-                } else {
-                  cb(except.IAE('Multiple results for sharerId[%s],userId[%s], shouldn\'t happen', sharerId, userId));
-                  cb = function(){};
-                }
-              })
-          .on('error', cb)
-          .on('end', function(){
-            doneCb();
-            cb(null, retVal);
-          });
+          let permissions = null;
+          if (data != null && data.length > 0) {
+            permissions = _.map(data, function(p) {
+              return p.permissions;
+            });
+            permissions = _.merge({}, ...permissions);
+          }
+
+          doneCb();
+          cb(null, permissions);
+        });
       });
     },
     usersInGroup: function(sharerId, cb) {

--- a/lib/dataBroker.js
+++ b/lib/dataBroker.js
@@ -35,36 +35,36 @@ module.exports = function(mongoClient) {
           // Find all user (subject) -> user (principal) permissions
           { $match: {'sharerId': sharerId, 'userId': userId} },
           // Find all user (subject) -> clinic -> clinician (principal) permissions
-          { $unionWith:
-              {
-                coll: 'patient_permissions',
-                pipeline: [
-                  // Find all patient -> clinic permissions
-                  { $match: {'userId': sharerId } },
-                  { $lookup: {
-                      // Join all clinic -> clinician permissions
-                      from: 'clinician_permissions',
-                      let: { clinicId: '$clinicId' },
-                      as: 'clinician',
-                      pipeline: [
-                        { $match: {
-                            $expr: {
-                              $and: [
-                                // Join on clinician = userId (principal)
-                                { $eq: ['$userId', userId]},
-                                { $eq: ['$clinicId','$$clinicId']},
-                              ]
-                            }
-                          }},
-                        { $project: { 'clinicianId': '$userId' } },
-                      ],
-                    }},
-                  { $unwind: { path: '$clinician', preserveNullAndEmptyArrays: true } },
-                  { $replaceRoot: { newRoot: { $mergeObjects: [ '$clinician', '$$ROOT' ] } } },
-                  { $match: { 'clinicianId': { $exists: true } } },
-                  { $project: { _id: 0, permissions: 1 } },
-                ]
-              }
+          { $unionWith: {
+              coll: 'patient_permissions',
+              pipeline: [
+                // Find all patient -> clinic permissions
+                { $match: {'userId': sharerId } },
+                { $lookup: {
+                    // Join all clinic -> clinician permissions
+                    from: 'clinician_permissions',
+                    let: { clinicId: '$clinicId' },
+                    as: 'clinician',
+                    pipeline: [
+                      { $match: {
+                          $expr: {
+                            $and: [
+                              // Join on clinician = userId (principal)
+                              { $eq: ['$userId', userId]},
+                              { $eq: ['$clinicId','$$clinicId']},
+                            ]
+                          }
+                        }},
+                      { $project: { 'clinicianId': '$userId' } },
+                    ],
+                  }
+                },
+                { $unwind: { path: '$clinician', preserveNullAndEmptyArrays: true } },
+                { $replaceRoot: { newRoot: { $mergeObjects: [ '$clinician', '$$ROOT' ] } } },
+                { $match: { 'clinicianId': { $exists: true } } },
+                { $project: { _id: 0, permissions: 1 } },
+              ]
+            }
           },
         ]).toArray(function (err, data) {
           if (err != null) {

--- a/lib/mongo/mongoClient.js
+++ b/lib/mongo/mongoClient.js
@@ -151,6 +151,35 @@ module.exports = function (config) {
           }
         );
 
+        mongoClient.db(databaseName).createIndex('patient_permissions',
+          {
+            'userId': 1,
+          },
+          {
+            'background': true,
+          },
+          function (indexError) {
+            if (indexError) {
+              return cb(indexError);
+            }
+          }
+        );
+
+        mongoClient.db(databaseName).createIndex('clinician_permissions',
+          {
+            'userId': 1,
+            'clinicId': 1,
+          },
+          {
+            'background': true,
+          },
+          function (indexError) {
+            if (indexError) {
+              return cb(indexError);
+            }
+          }
+        );
+
         cb(err);
       });
     },


### PR DESCRIPTION
Gatekeeper will make use of the CDC replicated `patient_permissions` and `clinician_permission` when checking whether a user is authorized for accessing another user.

The `$unionWith` pipeline aggregation stage requires Mongo 4.4 (which is now deployed in all environments)

This PR has been deployed in dev1 so it went through QA already.